### PR TITLE
align cellid 'system' field with other detectors

### DIFF
--- a/Detector/DRcalo/compact/DRcalo.xml
+++ b/Detector/DRcalo/compact/DRcalo.xml
@@ -703,7 +703,7 @@
     <readout name="DRcaloSiPMreadout">
       <segmentation type="GridDRcalo"/>
       <!-- Mendatory to use the first 32 bits for tower infos & the last 32 bits for fiber/SiPM infos -->
-      <id>system:2,eta:-8,phi:9,xmax:32:6,ymax:6,x:6,y:6,c:1,module:2</id>
+      <id>system:5,eta:-8,phi:9,xmax:32:6,ymax:6,x:6,y:6,c:1,module:2</id>
     </readout>
   </readouts>
 


### PR DESCRIPTION
The `system` field of the cellid is usually used to distinguish the different detector subsystems. - So 0 for tracker, 1 for calorimeter etc. This is also useful to look up the readout definition. It therefore should be the same size for all the different detector subsystems - usually that is 4 or 5 bits.