### PR TITLE
SiPMAdc is still experimental and under discussion

### DIFF
--- a/DRdigi/include/DigiSiPM.h
+++ b/DRdigi/include/DigiSiPM.h
@@ -39,7 +39,7 @@ private:
   Gaudi::Property<double> m_recovery{this, "recovery", 10., "SiPM cell recovery time in ns"}; // https://arxiv.org/abs/2001.10322
   Gaudi::Property<double> m_cellPitch{this, "cellpitch", 10., "SiPM cell size in um"};
   Gaudi::Property<double> m_afterpulse{this, "afterpulse", 0.03, "afterpulse probability"};
-  Gaudi::Property<double> m_falltimeFast{this, "falltimeFast", 6.5, "signal fast component decay time in ns"};  // This looks too fast
+  Gaudi::Property<double> m_falltimeFast{this, "falltimeFast", 6.5, "signal fast component decay time in ns"};
   Gaudi::Property<double> m_risetime{this, "risetime", 1., "signal rise time in ns"};
   Gaudi::Property<double> m_snr{this, "SNR", 30., "SNR value in dB"};
 

--- a/DRdigi/include/DigiSiPM.h
+++ b/DRdigi/include/DigiSiPM.h
@@ -11,7 +11,6 @@
 #include "GaudiKernel/ToolHandle.h"
 
 #include "SiPMSensor.h"
-#include "SiPMAdc.h"
 
 class DigiSiPM : public GaudiAlgorithm {
 public:
@@ -30,7 +29,6 @@ private:
   DataHandle<edm4hep::SparseVectorCollection> m_waveforms{"DigiWaveforms", Gaudi::DataHandle::Writer, this};
 
   std::unique_ptr<sipm::SiPMSensor> m_sensor;
-  std::unique_ptr<sipm::SiPMAdc> m_adc;
 
   // Hamamatsu S14160-1310PS
   Gaudi::Property<double> m_sigLength{this, "signalLength", 200., "signal length in ns"};
@@ -41,20 +39,14 @@ private:
   Gaudi::Property<double> m_recovery{this, "recovery", 10., "SiPM cell recovery time in ns"}; // https://arxiv.org/abs/2001.10322
   Gaudi::Property<double> m_cellPitch{this, "cellpitch", 10., "SiPM cell size in um"};
   Gaudi::Property<double> m_afterpulse{this, "afterpulse", 0.03, "afterpulse probability"};
-  Gaudi::Property<double> m_falltimeFast{this, "falltimeFast", 6.5, "signal fast component decay time in ns"};
+  Gaudi::Property<double> m_falltimeFast{this, "falltimeFast", 6.5, "signal fast component decay time in ns"};  // This looks too fast
   Gaudi::Property<double> m_risetime{this, "risetime", 1., "signal rise time in ns"};
   Gaudi::Property<double> m_snr{this, "SNR", 30., "SNR value in dB"};
 
-  // ADC parameters
-  Gaudi::Property<unsigned int> m_bits{this, "bits", 14, "ADC bits"};
-  Gaudi::Property<double> m_range{this, "range", std::pow(2., 13.), "ADC output range"};
-  Gaudi::Property<double> m_gain{this, "gain", 13.979, "ADC gain in dB i.e. gain(linear) = 10^(m_gain/20)"};
-  // reciprocal_width (multiplication factor) = 1. / (range / gain(linear) / 2^bits);
-
   // integration parameters
   Gaudi::Property<double> m_gateStart{this, "gateStart", 10., "Integration gate starting time in ns"};
-  Gaudi::Property<double> m_gateL{this, "gateLength", 90., "Integration gate length in ns"};
-  Gaudi::Property<int> m_thres{this, "threshold", static_cast<int>( 1.5 * 10. ), "Integration threshold"};
+  Gaudi::Property<double> m_gateL{this, "gateLength", 90., "Integration gate length in ns"};  // Should be approx 5 times fallTimeFast (see above)
+  Gaudi::Property<double> m_thres{this, "threshold", 1.5, "Integration threshold"};  // Threshold in pe (1.5 to suppress DCR)
 };
 
 #endif

--- a/DRdigi/src/DigiSiPM.cpp
+++ b/DRdigi/src/DigiSiPM.cpp
@@ -64,13 +64,13 @@ StatusCode DigiSiPM::execute() {
     // Using only analog signal (ADC conversion is still experimental)
     const sipm::SiPMAnalogSignal anaSignal = m_sensor->signal();
 
-    const double integral = anaSignal.integral(m_gateStart,m_gateL,m_thres);   // (intStart, intGate, threshold)
-    const double toa = anaSignal.toa(m_gateStart,m_gateL,m_thres);          // (intStart, intGate, threshold)
+    const double integral = anaSignal.integral(m_gateStart,m_gateL,m_thres); // (intStart, intGate, threshold)
+    const double toa = anaSignal.toa(m_gateStart,m_gateL,m_thres);           // (intStart, intGate, threshold)
 
     digiHit.setAmplitude( integral );
     digiHit.setCellID( rawhit.getCellID() );
     // Toa and m_gateStart are in ns
-    digiHit.setTimeStamp( static_cast<int>(toa+m_gateStart) );
+    digiHit.setTimeStamp( static_cast<int>((toa+m_gateStart)/m_sampling) );
     waveform.setAssocObj( edm4hep::ObjectID( digiHit.getObjectID() ) );
     waveform.setSampling( m_sampling );
 

--- a/DRdigi/src/DigiSiPM.cpp
+++ b/DRdigi/src/DigiSiPM.cpp
@@ -27,8 +27,6 @@ StatusCode DigiSiPM::initialize() {
 
   m_sensor = std::make_unique<sipm::SiPMSensor>(properties); // must be constructed from SiPMProperties
 
-  m_adc = std::make_unique<sipm::SiPMAdc>(m_bits,m_range,m_gain);
-
   info() << "DigiSiPM initialized" << endmsg;
 
   return StatusCode::SUCCESS;
@@ -63,22 +61,22 @@ StatusCode DigiSiPM::execute() {
     auto digiHit = digiHits->create();
     auto waveform = waveforms->create();
 
-    sipm::SiPMAnalogSignal anaSignal = m_sensor->signal();
-    sipm::SiPMDigitalSignal digiSignal = m_adc->digitize(anaSignal);
+    // Using only analog signal (ADC conversion is still experimental)
+    const sipm::SiPMAnalogSignal anaSignal = m_sensor->signal();
 
-    int integral = digiSignal.integral(m_gateStart,m_gateL,m_thres);   // (intStart, intGate, threshold)
-    double toa = digiSignal.toa(m_gateStart,m_gateL,m_thres);          // (intStart, intGate, threshold)
+    const double integral = anaSignal.integral(m_gateStart,m_gateL,m_thres);   // (intStart, intGate, threshold)
+    const double toa = anaSignal.toa(m_gateStart,m_gateL,m_thres);          // (intStart, intGate, threshold)
 
     digiHit.setAmplitude( integral );
     digiHit.setCellID( rawhit.getCellID() );
-    digiHit.setTimeStamp( static_cast<int>((toa+m_gateStart)/m_sampling) );
+    // Toa and m_gateStart are in ns
+    digiHit.setTimeStamp( static_cast<int>(toa+m_gateStart) );
     waveform.setAssocObj( edm4hep::ObjectID( digiHit.getObjectID() ) );
     waveform.setSampling( m_sampling );
 
-    std::vector<int> waveformVec = digiSignal.waveform();
-
-    for (unsigned bin = 0; bin < waveformVec.size(); bin++) {
-      int amp = waveformVec.at(bin);
+    // sipm::SiPMAnalogSignal can be iterated as an std::vector<double>
+    for (unsigned bin = 0; bin < anaSignal.size(); bin++) {
+      double amp = anaSignal[bin];
 
       if (amp < m_thres) continue;
 


### PR DESCRIPTION
Changes proposed in this pull-request:
- Removed SiPMDigitalSignal and SiPMAdc since they are still experimental. SiPM simulation now gives a SiPMAnalogSignal that can be managed in the same way. The output is basically the same, except that integral is now a double
- Modified threshold parameter. When using analog signals a signal amplitude of 1 corresponds to 1 photoelectron. Hence the threshold has been set to 1.5 to suppress DCR
- Removed copy of SiPMAnalogSignal.waveform into a std::vector. Each sample of SiPMAnalogSignal can be accessed using [i] operator.

To be done:

- [x] Build and check if everything is working fine
